### PR TITLE
Update gem to use Lightcast Classification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 An API client for the Lightcast REST APIs in ruby.
 
-Lightcast APIs documentation can be found here:
+Lightcast Classification APIs documentation can be found here:
 
-https://docs.lightcast.dev/apis
+https://docs.lightcast.dev/apis/classification
 
 ## Installation
 
@@ -29,7 +29,7 @@ Create your client
 client = Lightcast::Client.new(
   client_id: '123ABC'
   client_secret: '456DEF'
-  scope: 'profiles:us',
+  scope: 'classifications_api',
 )
 ```
 
@@ -46,7 +46,7 @@ Now you can make use of any of your available APIs for your client.
 You can access the skills API via
 
 ```ruby
-client.skills(version: 'latest')
+client.skills(version: '9.0.0', release: '2024.7')
 ```
 
 where the optional version is any valid version.
@@ -56,10 +56,10 @@ where the optional version is any valid version.
 Extract skills from plain text.
 
 ```ruby
-client.skills.extract({ text: 'blah blah blah' }, { language: 'en', confidence_threshold: 0.5 })
+skills.extract(text:'computer science is a cool thing to study')
 ```
 
-[API docs](https://docs.lightcast.dev/apis/skills#versions-version-extract)
+[API docs](https://docs.lightcast.dev/apis/classification#post-extract-skills)
 
 #### Skills Get
 
@@ -69,27 +69,46 @@ Get a single skill.
 client.skills.get(123)
 ```
 
-[API docs](https://docs.lightcast.dev/apis/skills#versions-version-skills-skill_id)
+[API docs](https://docs.lightcast.dev/apis/classification#get-get-a-concept-by-id)
+
+#### Skills List
+
+List skills.
+
+```ruby
+client.skills.post(
+   fields: ['name'],
+   filter: {
+     level: ['2'],
+     id: [
+      "someId",
+      "anotherId"
+     ]
+   },
+   limit: 5)
+```
+
+[API docs](https://docs.lightcast.dev/apis/classification#post-list-requested-taxonomy-concepts)
 
 #### Skills Related
 
 Get related skills from provided skills.
 
 ```ruby
-client.related.get(ids: ['12345', 'abcde'])
+client.related.get(ids: ['12345', 'abcde'], relationType: 'sibling')
 ```
 
-[API docs](https://docs.lightcast.dev/apis/skills#versions-version-related)
+[API docs](https://docs.lightcast.dev/apis/classification#post-list-requested-taxonomy-concepts)
 
 #### Skills Status
 
-Get the status of the skills API.
+Get the status of the classifications API.
 
 ```ruby
 client.skills.status
 ```
 
-[API docs](https://docs.lightcast.dev/apis/skills#status)
+[API docs](https://docs.lightcast.dev/apis/classification#get-get-service-status)
 
 ### Errors
 

--- a/lib/lightcast-ruby/authentication.rb
+++ b/lib/lightcast-ruby/authentication.rb
@@ -7,7 +7,8 @@ module Lightcast
                                       {
                                         client_id: @client_id,
                                         client_secret: @client_secret,
-                                        grant_type: 'client_credentials'
+                                        grant_type: 'client_credentials',
+                                        scope: @scope
                                       },
                                       {
                                         body: :form,

--- a/lib/lightcast-ruby/client.rb
+++ b/lib/lightcast-ruby/client.rb
@@ -7,7 +7,7 @@ module Lightcast
     include Lightcast::Authentication
 
     BASE_URL_AUTH     = 'https://auth.emsicloud.com'
-    BASE_URL_SERVICES = 'https://emsiservices.com'
+    BASE_URL_SERVICES = 'https://classification.emsicloud.com'
 
     def initialize(client_id:, client_secret:, scope:)
       @client_id      = client_id
@@ -18,15 +18,15 @@ module Lightcast
     end
 
     def connection_auth
-      Connection.new(url: BASE_URL_AUTH)
+      Connection.new(url: BASE_URL_AUTH, scope: @scope)
     end
 
     def connection_services
       Connection.new(access_token: @access_token, url: BASE_URL_SERVICES)
     end
 
-    def skills(version: 'latest')
-      @skills ||= Lightcast::Services::Skills.new(client: self, version: version)
+    def skills(version: '9.0.0', release: '2024.7')
+      @skills ||= Lightcast::Services::Skills.new(client: self, version: version, release: release)
     end
   end
 end

--- a/lib/lightcast-ruby/connection.rb
+++ b/lib/lightcast-ruby/connection.rb
@@ -6,9 +6,10 @@ module Lightcast
   class Connection
     attr_accessor :access_token, :url
 
-    def initialize(url:, access_token: nil)
+    def initialize(url:, access_token: nil, scope: 'classification_api')
       @access_token = access_token
       @url          = url
+      @scope = scope
     end
 
     def delete(path, **params)

--- a/lib/lightcast-ruby/services/skills.rb
+++ b/lib/lightcast-ruby/services/skills.rb
@@ -10,10 +10,6 @@ module Lightcast
       end
 
       def extract(**params)
-        # text: ''
-        # inputLocale: 'en-US'
-        # outputLocale: 'en-US'
-        # confidenceThreshold: 0.5
         @client.connection_services.post(
           "/classifications/#{@release}/skills/extract", **params
         )
@@ -24,14 +20,10 @@ module Lightcast
       end
 
       def list(**params)
-        # fields: ["name"]
-        # filter: {level: '2', id:[]}
         @client.connection_services.post("/taxonomies/skills/versions/#{@version}/concepts", **params)
       end
 
       def related(**params)
-        # ids: ['']
-        # relationType: 'sibling'
         @client.connection_services.post("/taxonomies/skills/versions/#{@version}/relations", **params)
       end
 

--- a/lib/lightcast-ruby/services/skills.rb
+++ b/lib/lightcast-ruby/services/skills.rb
@@ -3,31 +3,40 @@
 module Lightcast
   module Services
     class Skills
-      def initialize(client:, version:)
+      def initialize(client:, version:, release:)
         @client   = client
         @version  = version
+        @release = release
       end
 
-      def extract(body = {}, query = { language: 'en', confidence_threshold: 0 })
+      def extract(**params)
+        # text: ''
+        # inputLocale: 'en-US'
+        # outputLocale: 'en-US'
+        # confidenceThreshold: 0.5
         @client.connection_services.post(
-          "/skills/versions/#{@version}/extract?language=#{query[:language]}&confidenceThreshold=#{query[:confidence_threshold]}", body
+          "/classifications/#{@release}/skills/extract", **params
         )
       end
 
       def get(id)
-        @client.connection_services.get("/skills/versions/#{@version}/skills/#{id}")
+        @client.connection_services.get("/taxonomies/skills/versions/#{@version}/concepts/#{id}")
       end
 
       def list(**params)
-        @client.connection_services.get("/skills/versions/#{@version}/skills", **params)
+        # fields: ["name"]
+        # filter: {level: '2', id:[]}
+        @client.connection_services.post("/taxonomies/skills/versions/#{@version}/concepts", **params)
       end
 
       def related(**params)
-        @client.connection_services.post("/skills/versions/#{@version}/related", **params)
+        # ids: ['']
+        # relationType: 'sibling'
+        @client.connection_services.post("/taxonomies/skills/versions/#{@version}/relations", **params)
       end
 
       def status
-        @client.connection_services.get('/skills/status')
+        @client.connection_services.get('/status')
       end
     end
   end

--- a/spec/lightcast-ruby/authentication_spec.rb
+++ b/spec/lightcast-ruby/authentication_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Lightcast::Authentication do
   describe '#authenticate' do
     it 'issues the correct request' do
       stub = stub_request(:post, "#{Lightcast::Client::BASE_URL_AUTH}/connect/token")
-             .with(body: 'client_id=id&client_secret=secret&grant_type=client_credentials')
+             .with(body: 'client_id=id&client_secret=secret&grant_type=client_credentials&scope=scope')
 
       @client.authenticate
 

--- a/spec/lightcast-ruby/connection_spec.rb
+++ b/spec/lightcast-ruby/connection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Lightcast::Connection do
   subject { @connection }
 
   before do
-    @connection = described_class.new(url: 'https://foo.com/bar', access_token: 'token')
+    @connection = described_class.new(url: 'https://foo.com/bar', access_token: 'token', scope: 'scope')
   end
 
   # Class Methods


### PR DESCRIPTION
The Skills API will likely be deprecated by Lightcast within a year, use the [Classification API] (https://docs.lightcast.dev/apis/classification) instead.