### PR TITLE
Upgrade faraday to >=2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'faraday', '~> 1.0', '>= 1.0.0'
+gem 'faraday', '>= 2.0.1'
 
 group :development, :test do
   gem 'rake', '~> 13.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     lightcast-ruby (0.2.0)
-      faraday (~> 1.0, >= 1.0.0)
+      faraday (>= 2.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -13,32 +13,14 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     hashdiff (1.0.1)
     json (2.6.3)
-    multipart-post (2.3.0)
+    net-http (0.4.1)
+      uri
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -85,8 +67,8 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     unicode-display_width (2.4.2)
+    uri (0.13.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -98,7 +80,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  faraday (~> 1.0, >= 1.0.0)
+  faraday (>= 2.0.1)
   lightcast-ruby!
   rake (~> 13.0.6)
   rspec (~> 3.12.0)

--- a/lightcast-ruby.gemspec
+++ b/lightcast-ruby.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 2.0.1'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Our platform repo is reliant on at least 2.0.0 version of faraday. Upgrade faraday dependency in this gem so that it can be used with our platform project.

This will prevent the following error when trying to `bundle install` in `platform`:

```
Could not find compatible versions

Because tipalti-ruby >= 0.5.3 depends on faraday >= 2.0.1
  and every version of lightcast-ruby depends on faraday >= 1.0, < 2.A,
  tipalti-ruby >= 0.5.3 is incompatible with lightcast-ruby >= 0.
So, because Gemfile depends on lightcast-ruby ~> 0.2.0
  and Gemfile depends on tipalti-ruby ~> 0.5.3,
  version solving has failed.
```